### PR TITLE
Bug fix to avoid negative Chi-square test statistic within machine precision of 0.

### DIFF
--- a/R/ind_test_22.R
+++ b/R/ind_test_22.R
@@ -10,7 +10,6 @@
 #' @export
 
 ind_test_22 <- function(M,threshold=2,rounding=3){
-
 # calculate margins, total, expected table
 MC = apply(M,2,sum)
 ML = apply(M,1,sum)
@@ -33,7 +32,10 @@ if (df>0){ # perform test
    test_low = (sum(TT<threshold)>0)
    res[3] = test_low
    if (test_low) {
-   res[2] = stats::fisher.test(M)$p.value
+   res[2] = stats::fisher.test(M)$p.value    
+   if (abs(1 - res[2]) <= .Machine$double.eps){
+   res[2] <- 1 # If p-value is within machine precision of 1, then just set it to 1.
+   }
    res[1] = stats::qchisq(1-res[2],1)
    res[1] = round(res[1],rounding)
    res[2] = round(res[2],rounding)


### PR DESCRIPTION
I found a bug in the `int_test_22()` function. Here is a minimum working example:

```
> library(R2ucare)
> m <- matrix(c(16, 1, 60, 4), nrow = 2)
> R2ucare:::ind_test_22(m, 2)
[1] "NaN"    "1"      "NaN"    "Fisher"
Warning message:
In stats::qchisq(1 - res[2], 1) : NaNs produced
```

The problem seems to be that `fisher.test()` p-value is supposed to be exactly 1, but when you subtract the p-value away from 1, you get a number that equals negative machine precision:
```
> fisher.test(m)$p.value
[1] 1
> 1 - fisher.test(m)$p.value
[1] -2.220446e-16
> 1 - fisher.test(m)$p.value == -.Machine$double.eps
[1] TRUE
```
So when you provide `1 - fisher.test(m)$p.value` as the main argument to `qchisq()`, then you get `NaN` because Chi-square is undefined for negative values.

This fix checks to see if `fisher.test(m)$p.value` is within machine precision of 1, and sets it to exactly 1 if so. This means that `qchisq()` receives an argument exactly equal to zero, in which case it returns exactly 0 instead of `NaN`:
```
> library(R2ucare)
> m <- matrix(c(16, 1, 60, 4), nrow = 2)
> R2ucare:::ind_test_22(m, 2)
[1] "0"      "1"      "0"      "Fisher"
```

This problem might appear elsewhere (e.g. in other `ind_test_*()` functions), but I haven't checked.